### PR TITLE
Document double-click installation on Windows

### DIFF
--- a/labs/shipped-bootstrap-project/1.md
+++ b/labs/shipped-bootstrap-project/1.md
@@ -54,6 +54,8 @@ This process varies for each development platform. Follow the instructions given
  
 	**Note:** The command you are given is automatically generated for the OS on your local computer. To get the code to bootstrap  to another OS, click the appropriate icon at the bottom of the page.
 
+    **Note:** Some older versions of Windows do not support Powershell, which is used in the command presented by the UI. You can also install Shipped on Windows by double-clicking the [shipped-install download link](https://bintray.com/artifact/download/shippedrepos/shipped-install/windows/shipped-install.exe)
+
 1. After the first command has completed, from the Create Your Project form, copy and paste the text from the second box into a terminal window on your computer, then press **Enter**.
 
 	Shipped creates the project directory in a subdirectory of the working directory of the terminal window.


### PR DESCRIPTION
Resolves issue 46 (Powershell install fails on older versions of Windows)
